### PR TITLE
Remove the use of "const" for IE9 & IE10 browser compatibility

### DIFF
--- a/lib/schema-inspector.js
+++ b/lib/schema-inspector.js
@@ -1217,8 +1217,8 @@ TODO: Handler theses fields properly
 */
 	// ---------------------------------------------------------------------------
 
-	const INT_MIN = -2147483648;
-	const INT_MAX = 2147483647;
+	var INT_MIN = -2147483648;
+	var INT_MAX = 2147483647;
 
 	var _rand = {
 		int: function (min, max) {


### PR DESCRIPTION
IE 9 & IE 10 does not support the "const" keyword

http://kangax.github.io/compat-table/es6/#const

so we removed it to support those browsers
