### PR TITLE
[Bower] Change main to index.js fixes bower's install process.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     }
   ],
   "description": "Schema-Inspector is a powerful tool to sanitize and validate JS objects.",
-  "main": "./lib/schema-inspector.js",
+  "main": "index.js",
   "keywords": [
     "schema-inspector",
     "validation",

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/schema-inspector');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "schema-inspector",
   "description": "Schema-Inspector is a powerful tool to sanitize and validate JS objects.",
   "version": "1.4.5",
-  "main": "./lib/schema-inspector.js",
+  "main": "index.js",
   "author": {
     "name": "Sebastien Chopin",
     "url" : "https://twitter.com/atinux"


### PR DESCRIPTION
### Problem

I wanted to use your library without having to include it in my repo explicitly, thus use `bower`, but found that it wrongly installed. Try it for yourself:

``` shell
$ bower cache clean
$ bower install schema-inspector
$ ls bower_components/schema-inspector
fonts       images      index.html  javascripts params.json stylesheets
$ ls bower_components/schema-inspector/javascripts/
headsmart.min.js main.js          modernizr.js
```

You can see that the directory structure created is wrong, I cannot use your library and the `lib/` is nowhere to be found.
### Fixed

I've created a repo of my own at [andreip/schema-inspector-testing](https://github.com/andreip/schema-inspector-testing) which I registered under the name of `schema-inspector-testing` with bower. The repo includes the same commit from this pull request.
You can checkout the registered repo. You'll see it creates the **correct** directory structure now:

``` shell
$ bower search schema-inspector-testing
$ bower install schema-inspector-testing
$ ls bower_components/schema-inspector-testing/
LICENSE      Makefile     README.md    bower.json   index.js     lib          misc         package.json
$ ls bower_components/schema-inspector-testing/lib/
schema-inspector.js
```

NOTE: Please consider improving your bower install, I'll just have to use my own version until this is fixed.
Also, I'm no expert in this, so I may have it somehow wrong, feel free to correct me.
