### PR TITLE
Check if object `hasProperty`

### DIFF
--- a/lib/schema-inspector.js
+++ b/lib/schema-inspector.js
@@ -80,7 +80,9 @@
 		this._custom = {};
 		if (custom != null) {
 			for (var key in custom) {
-				this._custom['$' + key] = custom[key];
+				if (custom.hasOwnProperty(key)){
+					this._custom['$' + key] = custom[key];
+				}
 			}
 		}
 
@@ -478,9 +480,12 @@
 			}
 			else {
 				for (var key in candidate) {
-					this._deeperArray(key);
-					this._validate(items, candidate[key]);
-					this._back();
+					if (candidate.hasOwnProperty(key)){
+						this._deeperArray(key);
+						this._validate(items, candidate[key]);
+						this._back();						
+					}
+
 				}
 			}
 		}
@@ -1422,21 +1427,23 @@
 			var prop = schema.properties || {};
 
 			for (var key in prop) {
-				if (prop[key].optional === true && _rand.bool() === true) {
-					continue;
-				}
-				if (key !== '*') {
-					o[key] = this.generate(prop[key]);
-				}
-				else {
-					var rk = '__random_key_';
-					var randomKey = rk + 0;
-					var n = _rand.int(1, 9);
-					for (var i = 1; i <= n; i++) {
-						if (!(randomKey in prop)) {
-							o[randomKey] = this.generate(prop[key]);
+				if (prop.hasOwnProperty(key)){
+					if (prop[key].optional === true && _rand.bool() === true) {
+						continue;
+					}
+					if (key !== '*') {
+						o[key] = this.generate(prop[key]);
+					}
+					else {
+						var rk = '__random_key_';
+						var randomKey = rk + 0;
+						var n = _rand.int(1, 9);
+						for (var i = 1; i <= n; i++) {
+							if (!(randomKey in prop)) {
+								o[randomKey] = this.generate(prop[key]);
+							}
+							randomKey = rk + i;
 						}
-						randomKey = rk + i;
 					}
 				}
 			}


### PR DESCRIPTION
I really love the work you've done with this library! It's a great API and the error messages are fantastic. I added the `hasProperty` check because I had some properties on the prototype that was causing this to break. The `hasProperty` check prevents iterating over the object's prototype properties or properties that are not enumerable.

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in

