### PR TITLE
Change version of async dep to ~2.6.3 for IE compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "http://atinux.github.io/schema-inspector/",
   "dependencies": {
-    "async": "^3.1.0"
+    "async": "~2.6.3"
   },
   "devDependencies": {
     "mocha": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,12 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-async@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.1.0.tgz#42b3b12ae1b74927b5217d8c0016baaf62463772"
-  integrity sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ==
+async@~2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  dependencies:
+    lodash "^4.17.14"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -373,7 +375,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.17.15:
+lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
@Atinux 
We've been sorting out the Node and IE compatibility issue in https://github.com/Atinux/schema-inspector/issues/77. By now, we've reached consensus that version 1.6.9 of schema-inspector accidentally had breaking changes because of its udnerlying async dependency.

I think moving from the version 3 branch to version 2 branch of async is a great next step because it resolves the breaking changes issue and async's maintainers have committed to maintaining their version 2 branch with IE compatibility and it will receive patches for CVEs until further notice: https://github.com/caolan/async/issues/1661#issuecomment-634374314

This PR changes us to 2.6.3 of async, and should keep us on the version 2 branch because of specifiying `~2.6.3`. It doesn't use `^2.6.3`, because we don't need new async features, just patches for CVEs. The PR does not increment the version of schema-inspector, because I notice you do the version increment in separate commits, so I'm respecting that pattern.